### PR TITLE
MAINT: Automatically wrap methods of `ConfigurationBaseLookupClient`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,14 @@
 CHANGELOG
 =========
 
-This project uses `semantic versioning <http://semver.org/>`_.
-This change log uses principles from `keep a changelog <http://keepachangelog.com/>`_.
+0.3.0 (6Dec21)
+--------------
 
-[Unreleased]
-------------
+- Automatically create `synchronous` and `asynchronous` modules.
+- Detect server errors (in particular if a token expires) and raise exceptions.
 
-Added
-^^^^^
+0.2.0 (30Aug21)
+---------------
 
 - ``dtool_lookup_api.lookup``
 - ``dtool_lookup_api.search``
@@ -16,23 +16,3 @@ Added
 - ``dtool_lookup_api.config``
 - ... as well as their asynchronous pendants within ``dtool_lookup_api.asynchronous`` ...
 - and the underlying core mechanisms within ``dtool_lookup_api.core.LookupClient```.
-
-
-Changed
-^^^^^^^
-
-
-Deprecated
-^^^^^^^^^^
-
-
-Removed
-^^^^^^^
-
-
-Fixed
-^^^^^
-
-
-Security
-^^^^^^^^

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,5 +1,6 @@
 Contributors
 ============
 
+- `Johannes Hörmman <https://github.com/jotelha/>`_ created this package.
 - `Tjelvar Olsson <https://github.com/tjelvar-olsson>`_ is the main developer behind the `dtool ecosystem <https://github.com/jic-dtool>`_ and this package leans heavily against the structure of his `dtool-lookup-client <https://github.com/jic-dtool/dtool-lookup-client>`_ and `dtool-lookup-server <https://github.com/jic-dtool/dtool-lookup-server>`_.
-- `Lars Pastewka <https://github.com/pastewka>`_ provided the core.LookupClient implementation
+- `Lars Pastewka <https://github.com/pastewka>`_ provided the initial `core.LookupClient` implementation.

--- a/dtool_lookup_api/__init__.py
+++ b/dtool_lookup_api/__init__.py
@@ -1,3 +1,27 @@
+#
+# Copyright 2020 Lars Pastewka, Johannes Laurin Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 """dtool_lookup_api package."""
 
 from .version import version as __version__

--- a/dtool_lookup_api/asynchronous.py
+++ b/dtool_lookup_api/asynchronous.py
@@ -1,74 +1,40 @@
+#
+# Copyright 2020 Lars Pastewka, Johannes Laurin Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 """dtool_lookup_client.async module."""
+
+import inspect
+
 from .core.LookupClient import ConfigurationBasedLookupClient
 
+# Import all methods from ConfigurationBasedLookupClient into the global namespace
+for name, func in inspect.getmembers(ConfigurationBasedLookupClient, predicate=inspect.isfunction):
+    async def _wrap_client(*args, **kwargs):
+        async with ConfigurationBasedLookupClient() as lookup_client:
+            return await getattr(lookup_client, name)(*args, **kwargs)
+        __doc__ = func.__doc__
 
-# TODO: instead of wrapping every method of LookupClient explicitly, automize
-
-async def all():
-    """Wraps around LookupClient method 'all'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.all()
-
-async def aggregate(aggregation):
-    """Wraps around LookupClient method 'aggregate'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.aggregate(aggregation)
-
-async def config():
-    """Wraps around LookupClient method 'config'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.config()
-
-
-async def lookup(uuid):
-    """Wraps around LookupClient method 'lookup'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.lookup(uuid)
-
-
-async def manifest(uri):
-    """Wraps around LookupClient method 'query'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.manifest(uri)
-
-
-async def query(query):
-    """Wraps around LookupClient method 'query'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.query(query)
-
-
-async def readme(uri):
-    """Wraps around LookupClient method 'readme'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.readme(uri)
-
-
-async def search(keyword=None):
-    """Wraps around LookupClient method 'search'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.search(keyword)
-
-
-async def list_users():
-    """Wraps around LookupClient method 'list_users'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.list_users()
-
-
-async def register_user(username, is_admin=False):
-    """Wraps around LookupClient method 'list_users'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.register_user(username, is_admin)
-
-
-async def permission_info(base_uri):
-    """Wraps around LookupClient method 'list_users'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.permission_info(base_uri)
-
-
-async def update_permissions(base_uri, users_with_search_permissions, users_with_register_permissions=[]):
-    """Wraps around LookupClient method 'list_users'."""
-    async with ConfigurationBasedLookupClient() as lookup_client:
-        return await lookup_client.update_permissions(base_uri, users_with_search_permissions, users_with_register_permissions)
+    # Import everything that does not start with an underscore
+    if not name.startswith('_'):
+        globals()[name] = _wrap_client

--- a/dtool_lookup_api/asynchronous.py
+++ b/dtool_lookup_api/asynchronous.py
@@ -28,6 +28,7 @@ import inspect
 
 from .core.LookupClient import ConfigurationBasedLookupClient
 
+
 class _WrapClient:
     def __init__(self, name, func):
         self._name = name

--- a/dtool_lookup_api/asynchronous.py
+++ b/dtool_lookup_api/asynchronous.py
@@ -34,7 +34,7 @@ class _WrapClient:
         self._func = func
         self.__doc__ = self._func.__doc__
 
-    async def __call__(*args, **kwargs):
+    async def __call__(self, *args, **kwargs):
         async with ConfigurationBasedLookupClient() as lookup_client:
             return await self._func(lookup_client, *args, **kwargs)
 

--- a/dtool_lookup_api/asynchronous.py
+++ b/dtool_lookup_api/asynchronous.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-"""dtool_lookup_client.async module."""
+"""Module that has asynchronous API access functions in its global scope."""
 
 import inspect
 

--- a/dtool_lookup_api/core/LookupClient.py
+++ b/dtool_lookup_api/core/LookupClient.py
@@ -97,7 +97,7 @@ class TokenBasedLookupClient:
         return {'Authorization': f'Bearer {self.token}'}
 
     def _check_json(self, json):
-        if 'msg' in json:
+        if isinstance(json, dict) and 'msg' in json:
             raise LookupServerError(json['msg'])
 
     async def _get(self, route):

--- a/dtool_lookup_api/core/__init__.py
+++ b/dtool_lookup_api/core/__init__.py
@@ -1,0 +1,23 @@
+#
+# Copyright 2020 Lars Pastewka, Johannes Laurin Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#

--- a/dtool_lookup_api/core/config.py
+++ b/dtool_lookup_api/core/config.py
@@ -1,3 +1,27 @@
+#
+# Copyright 2020 Lars Pastewka, Johannes Laurin Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 """dtool_lookup_api.core.config module."""
 
 import logging

--- a/dtool_lookup_api/synchronous.py
+++ b/dtool_lookup_api/synchronous.py
@@ -1,6 +1,31 @@
+#
+# Copyright 2020 Lars Pastewka, Johannes Laurin Hoermann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
 """dtool_lookup_api.sync module."""
 
 # TODO: make independent from external dependency
+
 from asgiref.sync import async_to_sync
 
 from . import asynchronous

--- a/dtool_lookup_api/synchronous.py
+++ b/dtool_lookup_api/synchronous.py
@@ -22,90 +22,28 @@
 # SOFTWARE.
 #
 
-"""dtool_lookup_api.sync module."""
+"""Module that has synchronous API access functions in its global scope."""
 
-# TODO: make independent from external dependency
-
+import inspect
 from asgiref.sync import async_to_sync
 
-from . import asynchronous
-
-# TODO: instead of ecplicitly wrapping every asynchronous method, automize
+from .core.LookupClient import ConfigurationBasedLookupClient
 
 
-@async_to_sync
-async def all():
-    """Wraps around asynchronous.config."""
-    return await asynchronous.all()
+class _WrapClient:
+    def __init__(self, name, func):
+        self._name = name
+        self._func = func
+        self.__doc__ = self._func.__doc__
+
+    @async_to_sync
+    async def __call__(self, *args, **kwargs):
+        async with ConfigurationBasedLookupClient() as lookup_client:
+            return await self._func(lookup_client, *args, **kwargs)
 
 
-@async_to_sync
-async def aggregate(aggregation):
-    """Wraps around asynchronous.aggregate."""
-    return await asynchronous.aggregate(aggregation)
-
-
-@async_to_sync
-async def config():
-    """Wraps around asynchronous.config."""
-    return await asynchronous.config()
-
-
-@async_to_sync
-async def lookup(uuid):
-    """Wraps around asynchronous.lookup."""
-    return await asynchronous.lookup(uuid)
-
-
-@async_to_sync
-async def manifest(uri):
-    """Wraps around asynchronous.manifest."""
-    return await asynchronous.manifest(uri)
-
-
-@async_to_sync
-async def query(query):
-    """Wraps around asynchronous.query."""
-    return await asynchronous.query(query)
-
-
-@async_to_sync
-async def readme(uri):
-    """Wraps around asynchronous.uri."""
-    return await asynchronous.readme(uri)
-
-
-@async_to_sync
-async def search(keyword=None):
-    """Wraps around asynchronous.search."""
-    return await asynchronous.search(keyword)
-
-
-@async_to_sync
-async def user_info(user):
-    """Wraps around asynchronous.list_users."""
-    return await asynchronous.user_info(user)
-
-
-@async_to_sync
-async def list_users():
-    """Wraps around asynchronous.search."""
-    return await asynchronous.list_users()
-
-
-@async_to_sync
-async def register_user(username, is_admin=False):
-    """Wraps around asynchronous.search."""
-    return await asynchronous.register_user(username, is_admin)
-
-
-@async_to_sync
-async def permission_info(base_uri):
-    """Wraps around asynchronous.search."""
-    return await asynchronous.permission_info(base_uri)
-
-
-@async_to_sync
-async def update_permissions(base_uri, users_with_search_permissions, users_with_register_permissions=[]):
-    """Wraps around asynchronous.search."""
-    return await asynchronous.register_user(base_uri, users_with_search_permissions, users_with_register_permissions)
+# Import all methods from ConfigurationBasedLookupClient into the global namespace
+for name, func in inspect.getmembers(ConfigurationBasedLookupClient, predicate=inspect.isfunction):
+    # Import everything that does not start with an underscore
+    if not name.startswith('_'):
+        globals()[name] = _WrapClient(name, func)


### PR DESCRIPTION
`TokenBasedLookupClient` has method for accessing the API of the lookup server. These methods are imported into the global scope of `asynchronous` and `synchronous` modules, to be easily used within scripts/code. This PR automatically imports all methods into the global scope, rather than having them wrapped manually.